### PR TITLE
Add ClearClipboardAfterCapture option for screenshots

### DIFF
--- a/ShareX/ApplicationConfig.cs
+++ b/ShareX/ApplicationConfig.cs
@@ -281,6 +281,9 @@ namespace ShareX
         [Category("Drag and drop window"), DefaultValue(255), Description("When you drag file to drop window then opacity will change to this.")]
         public int DropHoverOpacity { get; set; }
 
+        [Category("Clipboard"), DefaultValue(false), Description("When you enable this option your clipboard will be cleared directly after you capture a screenshot.")]
+        public bool ClearClipboardAfterCapture { get; set; }
+
         #endregion Advanced
 
         #endregion Settings Form

--- a/ShareX/CaptureHelpers/CaptureBase.cs
+++ b/ShareX/CaptureHelpers/CaptureBase.cs
@@ -101,6 +101,11 @@ namespace ShareX
         {
             if (metadata != null && metadata.Image != null)
             {
+                if (taskSettings.AdvancedSettings.ClearClipboardAfterCapture)
+                {
+                    Clipboard.Clear();
+                }
+
                 TaskHelpers.PlayNotificationSoundAsync(NotificationSound.Capture, taskSettings);
 
                 if (taskSettings.AfterCaptureJob.HasFlag(AfterCaptureTasks.AnnotateImage) && !AllowAnnotation)

--- a/ShareX/TaskSettings.cs
+++ b/ShareX/TaskSettings.cs
@@ -487,6 +487,9 @@ namespace ShareX
         [Category("Capture"), DefaultValue(false), Description("Disable annotation support in region capture.")]
         public bool RegionCaptureDisableAnnotation { get; set; }
 
+        [Category("Capture"), DefaultValue(false), Description("When you enable this option your clipboard will be cleared directly after you capture a screenshot.")]
+        public bool ClearClipboardAfterCapture { get; set; }
+
         [Category("Upload"), Description("Files with these file extensions will be uploaded using image uploader."),
         Editor("System.Windows.Forms.Design.StringCollectionEditor,System.Design, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a", typeof(UITypeEditor))]
         public List<string> ImageExtensions { get; set; }


### PR DESCRIPTION
Introduce a new boolean property `ClearClipboardAfterCapture` in `ApplicationConfig.cs` and `TaskSettings.cs` to allow users to clear the clipboard after capturing a screenshot. Update `CaptureInternal` in `CaptureBase.cs` to implement this functionality.